### PR TITLE
Make use of CASE_LIGHT

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -438,12 +438,12 @@
 /**
  * M355 Case Light on-off / brightness
  */
-//#define CASE_LIGHT_ENABLE
+#define CASE_LIGHT_ENABLE
 #if ENABLED(CASE_LIGHT_ENABLE)
-  #define CASE_LIGHT_PIN 45                   // Override the default pin if needed
+  #define CASE_LIGHT_PIN LED_PIN              // Override the default pin if needed
   #define INVERT_CASE_LIGHT false             // Set true if Case Light is ON when pin is LOW
   #define CASE_LIGHT_DEFAULT_ON true          // Set default power-up state on
-  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 255   // Set default power-up brightness (0-255, requires PWM pin)
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 20    // Set default power-up brightness (0-255, requires PWM pin)
   //#define CASE_LIGHT_MAX_PWM 128            // Limit pwm
   //#define CASE_LIGHT_MENU                   // Add Case Light options to the LCD menu
   //#define CASE_LIGHT_NO_BRIGHTNESS          // Disable brightness control. Enable for non-PWM lighting.

--- a/Marlin/src/lcd/extensible_ui/lib/dwin/DwinTFT.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dwin/DwinTFT.cpp
@@ -176,23 +176,6 @@ void DwinTFTClass::filamentRunout(const ExtUI::extruder_t extruder)
   #endif
 }
 
-void DwinTFTClass::setCaseLight(bool state)
-{
-  #if PIN_EXISTS(LED)
-    caseLight = state;
-    if(state) {
-        WRITE(LED_PIN, HIGH);
-    } else {
-        WRITE(LED_PIN, LOW);
-    }
-  #endif
-}
-
-bool DwinTFTClass::getCaseLight()
-{
-  return caseLight;
-}
-
 void DwinTFTClass::gcodeNow_P(PGM_P const gcode)
 {
   ExtUI::injectCommands_P(gcode);

--- a/Marlin/src/lcd/extensible_ui/lib/dwin/DwinTFT.h
+++ b/Marlin/src/lcd/extensible_ui/lib/dwin/DwinTFT.h
@@ -72,8 +72,6 @@ public:
   void kill();
   void tick();
   void filamentRunout(const ExtUI::extruder_t extruder);
-  void setCaseLight(bool state);
-  bool getCaseLight();
   void gcodeNow_P(PGM_P const gcode);
   void gcodeQueue_P(PGM_P const gcode);
   void gcodeQueue(const char* gcode);

--- a/Marlin/src/lcd/extensible_ui/lib/dwin/DwinTFTCommand.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dwin/DwinTFTCommand.cpp
@@ -579,7 +579,7 @@ void DwinTFTCommandClass::sendAutoPowerOff()
 
 void DwinTFTCommandClass::sendSetCaseLight()
 {
-  DwinTFT.setCaseLight(!DwinTFT.getCaseLight());
+  ExtUI::setCaseLightState(!ExtUI::getCaseLightState());
 }
 
 #endif


### PR DESCRIPTION
### Description

This allows to use 4max led strip as case light controlled both by TFT display and M355 gcode.

