### PR TITLE
use correct calculated junction_deviation value based on the stock acc

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -813,7 +813,7 @@
  *   http://blog.kyneticcnc.com/2018/10/computing-junction-deviation-for-marlin.html
  */
 #if DISABLED(CLASSIC_JERK)
-  #define JUNCTION_DEVIATION_MM 0.013 // (mm) Distance from real junction edge
+  #define JUNCTION_DEVIATION_MM 0.038 // (mm) Distance from real junction edge - 0.4 * (jerk^2 / accel_printing)
 #endif
 
 /**


### PR DESCRIPTION
Okay, found another thing..  this FW has `CLASSIC_JERK` disabled and uses the (newer) junction deviation per default. However - that value wasn't correctly calculated (actually, not at all, just taken from the i3).

Given the numbers from the stock fw (accel, jerk) the value should be 0.0384.

See:
https://reprap.org/forum/read.php?1,739819
and
http://blog.kyneticcnc.com/2018/10/computing-junction-deviation-for-marlin.html